### PR TITLE
don't resize o_buf in VpXDecoder (fixes #10)

### DIFF
--- a/aiortc/codecs/vpx.py
+++ b/aiortc/codecs/vpx.py
@@ -149,7 +149,7 @@ class VpxDecoder:
                     div = p and 2 or 1
                     o_stride = img.d_w // div
                     for r in range(0, img.d_h // div):
-                        o_buf[o_pos:o_pos + o_stride] = i_buf[i_pos:i_pos + i_stride]
+                        o_buf[o_pos:o_pos + o_stride] = i_buf[i_pos:i_pos + o_stride]
                         i_pos += i_stride
                         o_pos += o_stride
 


### PR DESCRIPTION
I think this is correct. This prevents the `o_buf` array being resized. It appears that `i_stride` is usually bigger than `o_stride` so the slices were mismatched and `o_buf` was being resized.