### PR TITLE
WIP - Add iceServers support at RTCConfiguration

### DIFF
--- a/aiortc/__init__.py
+++ b/aiortc/__init__.py
@@ -1,6 +1,6 @@
 from .exceptions import InvalidAccessError, InvalidStateError  # noqa
 from .mediastreams import AudioStreamTrack, VideoStreamTrack  # noqa
-from .rtcconfiguration import RTCConfiguration  # noqa
+from .rtcconfiguration import RTCConfiguration, RTCIceServer  # noqa
 from .rtcdatachannel import RTCDataChannel, RTCDataChannelParameters  # noqa
 from .rtcdtlstransport import (RTCCertificate, RTCDtlsFingerprint,  # noqa
                                RTCDtlsParameters, RTCDtlsTransport)

--- a/aiortc/rtcconfiguration.py
+++ b/aiortc/rtcconfiguration.py
@@ -4,7 +4,8 @@ import attr
 @attr.s
 class RTCConfiguration:
     bundlePolicy = attr.ib(default='max-compat')
-    iceServers = attr.ib(factory=lambda: [RTCIceServer('stun:stun.l.google.com:19302')])
+    iceServers = attr.ib(
+        default=attr.Factory(lambda: [RTCIceServer('stun:stun.l.google.com:19302')]))
 
 
 @attr.s

--- a/aiortc/rtcconfiguration.py
+++ b/aiortc/rtcconfiguration.py
@@ -4,3 +4,21 @@ import attr
 @attr.s
 class RTCConfiguration:
     bundlePolicy = attr.ib(default='max-compat')
+    iceServers = attr.ib(factory=lambda: [RTCIceServer('stun:stun.l.google.com:19302')])
+
+
+@attr.s
+class RTCIceServer:
+    urls = attr.ib()
+    username = attr.ib(default=None)
+    credential = attr.ib(default=None)
+    credentialType = attr.ib(default="password")
+
+    @classmethod
+    def fromdict(cls, server):
+        return cls(
+            server.get('urls', server.get('url')),
+            server.get('username'),
+            server.get('credential'),
+            server.get('credentialType', "password")
+        )

--- a/aiortc/rtcpeerconnection.py
+++ b/aiortc/rtcpeerconnection.py
@@ -431,7 +431,7 @@ class RTCPeerConnection(EventEmitter):
 
     def __createDtlsTransport(self):
         # create ICE transport
-        iceGatherer = RTCIceGatherer()
+        iceGatherer = RTCIceGatherer(servers=self.__configuration.iceServers)
         iceGatherer.on('statechange', self.__updateIceGatheringState)
         iceTransport = RTCIceTransport(iceGatherer)
         iceTransport.on('statechange', self.__updateIceConnectionState)

--- a/aiortc/utils.py
+++ b/aiortc/utils.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+import re
 from struct import unpack
 
 
@@ -22,3 +23,25 @@ async def first_completed(*coros, timeout=None):
         return done.pop().result()
     else:
         raise TimeoutError
+
+STUN_REGEX = '(?P<scheme>stun|stuns)\:(?P<host>[^?:]+)(\:(?P<port>[0-9]+?))?'
+TURN_REGEX = ('(?P<scheme>turn|turns)\:(?P<host>[^?:]+)(\:(?P<port>[0-9]+?))?'
+              '(\?transport=(?P<transport>.*))?')
+
+
+def parse_stun_turn_uri(uri):
+    if uri.startswith('stun'):
+        match = re.fullmatch(STUN_REGEX, uri)
+    elif uri.startswith('turn'):
+        match = re.fullmatch(TURN_REGEX, uri)
+    else:
+        raise ValueError('malformed uri: invalid scheme')
+
+    if not match:
+        raise ValueError('malformed uri')
+
+    match = match.groupdict()
+    if match['port']:
+        match['port'] = int(match['port'])
+
+    return match


### PR DESCRIPTION
Closes #13 

Limitation: see https://github.com/jlaine/aioice/issues/3
- do not support multiples stun or turn server, the first of each is used
- do not support stuns or turns, it is ignored
- only support udp as transport to turn
- only support "password" credentials to turn

TODO:
- write a exemple
- write tests