### PR TITLE
[travis] build ffmpeg 3.2 from source

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,15 @@
 addons:
   apt:
     packages:
-    - libavdevice-dev
-    - libavfilter-dev
     - libopus-dev
     - libvpx-dev
-cache: pip
+    - libx264-dev
+    - yasm
+cache:
+  directories: $HOME/.local
+  pip: true
 dist: xenial
-install: .travis/install
+install: source .travis/install
 language: python
 matrix:
   include:
@@ -17,6 +19,7 @@ matrix:
   - python: "3.6"
   - python: "3.7"
   - env: BUILD=sdist
+    install: true
     python: "3.6"
 script: .travis/script
 sudo: true

--- a/.travis/install
+++ b/.travis/install
@@ -2,10 +2,24 @@
 
 set -e
 
+PREFIX=$HOME/.local
+
 if [ "$(uname -s)" = "Darwin" ]; then
     brew update
     brew upgrade python3
     brew install ffmpeg opus libvpx
+elif [ ! -e "$PREFIX/bin/ffmpeg" ]; then
+    curl http://www.ffmpeg.org/releases/ffmpeg-3.2.12.tar.xz | tar xJ
+    cd ffmpeg-3.2.12
+    ./configure --prefix=$PREFIX \
+        --disable-static --enable-shared \
+        --enable-gpl --enable-libx264
+    make
+    make install
+    cd ..
+
+    export LD_LIBRARY_PATH=$PREFIX/lib
+    export PKG_CONFIG_PATH=$PREFIX/lib/pkgconfig
 fi
 
 pip3 install -U setuptools


### PR DESCRIPTION
PyAV now requires ffmpeg >= 3.0, which Ubuntu 16.04 does not have.