### PR TITLE
[examples] Get datachannel-cli working in python3

### DIFF
--- a/aiortc/contrib/signaling.py
+++ b/aiortc/contrib/signaling.py
@@ -63,7 +63,7 @@ class CopyAndPasteSignaling:
         print('-- Please enter a message from remote party --')
         descr_str = await self._reader.readline()
         print()
-        return object_from_string(descr_str)
+        return object_from_string(descr_str.decode('utf8'))
 
     async def send(self, descr):
         print('-- Please send this message to the remote party --')


### PR DESCRIPTION
When running the datachannel-cli demo in python3, it crashes in
json.loads() due to the readline() returning bytes instead of a string.
The parameter to object_from_string() in CopyAndPasteSignaling.receive()
was modified so it looks more like other calls to object_from_string()
in contrib/signaling.py, I.E. added .decode('utf8') to its parameter.