### PR TITLE
Throw away empty rtp packet

### DIFF
--- a/aiortc/rtcrtpreceiver.py
+++ b/aiortc/rtcrtpreceiver.py
@@ -366,6 +366,8 @@ class RTCRtpReceiver:
         Handle an incoming RTP packet.
         """
         self.__log_debug('< %s', packet)
+        if len(packet.payload) <1:
+            return
 
         # feed bitrate estimator
         if self.__remote_bitrate_estimator is not None:


### PR DESCRIPTION
Hi jlaine:
It looks like the issue 129 is related to the rtp empy packet.
fix issue #129 